### PR TITLE
Fix Build Error

### DIFF
--- a/noncehelper/nonce-uc.m
+++ b/noncehelper/nonce-uc.m
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <mach/mach_error.h>
 #import <Foundation/Foundation.h>
 #import <CoreFoundation/CoreFoundation.h>
 #import <IOKit/IOKitLib.h>


### PR DESCRIPTION
declaration of 'mach_error_string' must be imported from module 'Darwin.Mach.mach_error' before it is required